### PR TITLE
feat: initialize Serilog for application logging

### DIFF
--- a/Core/Application/Application.csproj
+++ b/Core/Application/Application.csproj
@@ -5,7 +5,8 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
     <PackageReference Include="Mapster" Version="7.4.0" />
     <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
-    <PackageReference Include="MediatR" Version="12.3.0" />
+    <PackageReference Include="MediatR" Version="12.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/Core/Application/RegisterApplication.cs
+++ b/Core/Application/RegisterApplication.cs
@@ -8,12 +8,13 @@ using FluentValidation;
 using MediatR;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Application
 {
     public static class RegisterApplication
     {
-        public static IServiceCollection AddApplication(this IServiceCollection services)
+        public static IServiceCollection AddApplication(this IServiceCollection services, ILogger logger)
         {
             try
             {
@@ -28,11 +29,11 @@ namespace Application
                 services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(RegisterApplication).Assembly));
 
 
-                Console.WriteLine($"Info: {nameof(Application)} layer initialized successfully.");
+                logger.LogInformation($"{nameof(Application)} layer initialized successfully.");
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error initializing {nameof(Application)} layer: {ex.Message}");
+                logger.LogError($"Error initializing {nameof(Application)} layer: {ex.Message}", ex);
             }
 
 

--- a/Core/Domain/Domain.csproj
+++ b/Core/Domain/Domain.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="12.3.0" />
+    <PackageReference Include="MediatR" Version="12.4.0" />
   </ItemGroup>
 
 </Project>

--- a/Infrastructure/Identity/Identity.csproj
+++ b/Infrastructure/Identity/Identity.csproj
@@ -8,11 +8,11 @@
   
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/Infrastructure/Persistence/Persistence.csproj
+++ b/Infrastructure/Persistence/Persistence.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
 

--- a/Infrastructure/Persistence/Speeds/ApplicationDbContextSeed.cs
+++ b/Infrastructure/Persistence/Speeds/ApplicationDbContextSeed.cs
@@ -7,12 +7,12 @@ namespace Persistence.Seeding
 {
     public static class ApplicationDbContextSeed
     {
-        public static void Seed(ApplicationDbContext dbContext)
+        public static async Task Seed(ApplicationDbContext dbContext)
         {
             if (!dbContext.Todos.Any())
             {
-                dbContext.Todos.AddRange(Todos);
-                dbContext.SaveChanges();
+                await dbContext.Todos.AddRangeAsync(Todos);
+                await dbContext.SaveChangesAsync();
             }
         }
         public static readonly List<Todo> Todos = new List<Todo>

--- a/Infrastructure/Shared/RegisterShared.cs
+++ b/Infrastructure/Shared/RegisterShared.cs
@@ -1,6 +1,7 @@
 ﻿using Application.Interfaces.Services;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using Shared.Services;
 
@@ -8,18 +9,18 @@ namespace Shared;
 
 public static class RegisterShared
 {
-    public static IServiceCollection AddShared(this IServiceCollection services)
+    public static IServiceCollection AddShared(this IServiceCollection services, ILogger logger)
     {
         try
         {
             services.AddScoped<IDateTimeService, DateTimeService>();
             services.AddScoped<IEmailService, EmailService>();
 
-            Console.WriteLine($"Info: {nameof(Shared)} layer initialized successfully.");
+            logger.LogInformation($"{nameof(Shared)} layer initialized successfully.");
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"Error initializing  {nameof(Shared)} layer: {ex.Message}");
+            logger.LogError($"Error initializing  {nameof(Shared)} layer: {ex.Message}",ex);
         }
         return services;
     }

--- a/Infrastructure/Shared/Shared.csproj
+++ b/Infrastructure/Shared/Shared.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.7.0" />
+    <PackageReference Include="MailKit" Version="4.7.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="MimeKit" Version="4.7.0" />
+    <PackageReference Include="MimeKit" Version="4.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Presentation/WebApi/Middleware/ErrorHandlerMiddleware.cs
+++ b/Presentation/WebApi/Middleware/ErrorHandlerMiddleware.cs
@@ -10,10 +10,12 @@ namespace WebApi.Middleware
     public class ErrorHandlerMiddleware
     {
         private readonly RequestDelegate _next;
+        private readonly ILogger<ErrorHandlerMiddleware> _logger;
 
-        public ErrorHandlerMiddleware(RequestDelegate next)
+        public ErrorHandlerMiddleware(RequestDelegate next, ILogger<ErrorHandlerMiddleware> logger)
         {
             _next = next;
+            _logger = logger;
         }
 
         public async Task Invoke(HttpContext context)
@@ -49,7 +51,7 @@ namespace WebApi.Middleware
                         break;
                 }
                 var result = JsonSerializer.Serialize(responseModel);
-
+                _logger.LogError(error, "ErrorHandlerMiddleware");
                 await response.WriteAsync(result);
             }
         }

--- a/Presentation/WebApi/Program.cs
+++ b/Presentation/WebApi/Program.cs
@@ -5,15 +5,32 @@ using Identity;
 
 using WebApi;
 using WebApi.Middleware;
+using Serilog;
+using Serilog.Extensions.Logging;
+
+var logger = new LoggerConfiguration()
+    .MinimumLevel.Verbose()
+    .Enrich.FromLogContext()
+    .WriteTo.Console(outputTemplate:
+        "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
+        theme: Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme.Literate)
+    .CreateLogger();
+
+
+logger.Information("Starting web host");
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Host.UseSerilog((_, config) => config.ReadFrom.Configuration(builder.Configuration));
+ILogger<Program> MicrosoftLogger = new SerilogLoggerFactory(logger!)
+    .CreateLogger<Program>();
+
 #region Layer
-builder.Services.AddShared();
-builder.Services.AddIdentityServices(builder.Configuration);
-builder.Services.AddPersistence(builder.Configuration);
-builder.Services.AddApplication();
-builder.Services.AddPresentation();
+builder.Services.AddShared(MicrosoftLogger);
+builder.Services.AddIdentityServices(builder.Configuration, MicrosoftLogger);
+builder.Services.AddPersistence(builder.Configuration, MicrosoftLogger);
+builder.Services.AddApplication(MicrosoftLogger);
+builder.Services.AddPresentation(MicrosoftLogger);
 #endregion
 
 var app = builder.Build();
@@ -27,10 +44,27 @@ if (app.Environment.IsDevelopment())
 }
 app.UseMiddleware<ErrorHandlerMiddleware>();
 app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseAuthorization();
+app.UseAuthorization();
+
 app.MapControllers();
 
-// Log application start
-var logger = app.Services.GetRequiredService<ILogger<Program>>();
-logger.LogInformation("Application started.");
+try
+{
+    await RegisterIdentity.SeedIdentityData(builder.Services, builder.Configuration, MicrosoftLogger);
+    await RegisterPersistence.SeedPersistenceData(builder.Services, builder.Configuration, MicrosoftLogger);
+}
+catch (Exception ex)
+{
+    MicrosoftLogger.LogError(ex, "An error occurred seeding the DB. {exceptionMessage}", ex.Message);
+}
+
+
+
+logger.Information("Web host started");
 
 app.Run();

--- a/Presentation/WebApi/RegisterPresentation.cs
+++ b/Presentation/WebApi/RegisterPresentation.cs
@@ -4,7 +4,7 @@ namespace WebApi
 {
     public static class RegisterPresentation
     {
-        public static IServiceCollection AddPresentation(this IServiceCollection services)
+        public static IServiceCollection AddPresentation(this IServiceCollection services, ILogger logger)
         {
             try
             {
@@ -46,11 +46,11 @@ namespace WebApi
                                           .AllowAnyMethod()
                                           .AllowAnyHeader());
                 });
-                Console.WriteLine($"Info: {nameof(WebApi)} layer initialized successfully.");
+                logger.LogInformation($"{nameof(WebApi)} layer initialized successfully.");
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error initializing {nameof(WebApi)} layer: {ex.Message}");
+                logger.LogError($"Error initializing {nameof(WebApi)} layer: {ex.Message}");
             }
 
             return services;

--- a/Presentation/WebApi/WebApi.csproj
+++ b/Presentation/WebApi/WebApi.csproj
@@ -7,16 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Presentation/WebApi/appsettings.Development.json
+++ b/Presentation/WebApi/appsettings.Development.json
@@ -1,9 +1,29 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information"
+    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+      //{
+      //  "Name": "File",
+      //  "Args": {
+      //    "path": "log.txt",
+      //    "rollingInterval": "Day"
+      //  }
+      //}
+      //Uncomment this section if you'd like to push your logs to Azure Application Insights
+      //Full list of Serilog Sinks can be found here: https://github.com/serilog/serilog/wiki/Provided-Sinks
+      //{
+      //  "Name": "ApplicationInsights",
+      //  "Args": {
+      //    "instrumentationKey": "", //Fill in with your ApplicationInsights InstrumentationKey
+      //    "telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
+      //  }
+      //}
+    ]
   },
   "AllowedHosts": "*",
   "UseInMemoryDatabase": true,

--- a/Presentation/WebApi/appsettings.json
+++ b/Presentation/WebApi/appsettings.json
@@ -1,9 +1,29 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Fatal"
+    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+      //{
+      //  "Name": "File",
+      //  "Args": {
+      //    "path": "log.txt",
+      //    "rollingInterval": "Day"
+      //  }
+      //}
+      //Uncomment this section if you'd like to push your logs to Azure Application Insights
+      //Full list of Serilog Sinks can be found here: https://github.com/serilog/serilog/wiki/Provided-Sinks
+      //{
+      //  "Name": "ApplicationInsights",
+      //  "Args": {
+      //    "instrumentationKey": "", //Fill in with your ApplicationInsights InstrumentationKey
+      //    "telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
+      //  }
+      //}
+    ]
   },
   "AllowedHosts": "*",
   "UseInMemoryDatabase": false,


### PR DESCRIPTION
Set up Serilog for structured logging in the application. Configured the logger to output to the console with a specific format and theme. Fixed an issue where seeding identity data was not handling exceptions correctly